### PR TITLE
Minor UI changes

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -24,7 +24,7 @@ table {
 }
 
 #timer {
-    color: #A3DAFD;
+    color: white;
     text-align: center;
 }
 #timer strong { font-size: 150px; }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         </header>
         <table>
             <tr id="timer">
-                <td><span id="timer_main"><strong>00:00:00</strong></span></td>
+                <td><span id="timer_main"><strong>&ndash;&ndash;:&ndash;&ndash;:&ndash;&ndash;</strong></span></td>
             </tr>
             <tr id="controls">
                 <td>


### PR DESCRIPTION
* The text now flashes when the counter reaches zero.
* The text is colored yellow when the counter is below 60.
* The counter can be below zero, in which case zero is shown, and the counter is used to record the state of the flashing text.
* The code to display the counter is fully moved to `updateCounter()` (previously, the timer handler was responsible if the counter was below 0)
* The counter is initialized by JS. The HTML page now shows n-dashes in the place of digits if the JS is (or can not) be loaded.

I added the `// vim:` line for my own convenience (to make sure vim indents the code properly).

On a less related note, please make the timer available on GH pages.