### PR TITLE
fix(timer): Reset input fields on timer reset

### DIFF
--- a/assets/countdown_timer.js
+++ b/assets/countdown_timer.js
@@ -100,6 +100,10 @@ function reset(){
     set_button.disabled = false;
     reset_button.disabled = true;
 
+    hour_input.value = "00";
+    min_input.value = "00";
+    sec_input.value = "00";
+
     setTime();
 }
 


### PR DESCRIPTION
The countdown timer's reset button did not reset the hour, minute, and second input fields to their default "00" values. It only reset the timer display using the current values from the inputs.

This commit updates the `reset()` function to explicitly set the input fields' values to "00", ensuring the UI returns to its initial state when the timer is reset.
